### PR TITLE
Add contact page with mockup form

### DIFF
--- a/.cursor/rules/moderails.md
+++ b/.cursor/rules/moderails.md
@@ -1,0 +1,21 @@
+---
+description: Core protocol for moderails-managed agents
+globs:
+alwaysApply: true
+---
+
+# moderails Agent Protocol
+
+You are a moderails-managed agent working in a git worktree.
+
+## Commands
+
+- `moderails mode next` -- get your next step instructions
+- `moderails mode current` -- re-read the current step (use after crash/restart)
+- `moderails run complete --summary "..."` -- save your execution summary (final step tells you when)
+
+## Rules
+
+1. Always run `moderails mode next` to get step instructions -- never guess
+2. Complete each step fully before moving to the next
+3. When the final step tells you to summarize, call `moderails run complete` and then stop

--- a/app/components/Footer.js
+++ b/app/components/Footer.js
@@ -30,7 +30,7 @@ export default function Footer() {
     { label: 'FAQ', href: '/faq' },
     { label: 'Shipping', href: '#' },
     { label: 'Returns', href: '#' },
-    { label: 'Contact', href: '#' },
+    { label: 'Contact', href: '/contact' },
   ]
 
   const legalLinks = [

--- a/app/components/Navigation.js
+++ b/app/components/Navigation.js
@@ -12,7 +12,7 @@ export default function Navigation() {
     { label: 'Pricing', href: '/pricing' },
     { label: 'Blog', href: '/blog' },
     { label: 'Learn More', href: '/learn-more' },
-    { label: 'Contact', href: '#' },
+    { label: 'Contact', href: '/contact' },
   ]
 
   return (

--- a/app/contact/page.js
+++ b/app/contact/page.js
@@ -1,0 +1,168 @@
+'use client'
+
+import { useState } from 'react'
+
+export default function Contact() {
+  const [formData, setFormData] = useState({
+    name: '',
+    email: '',
+    subject: '',
+    message: '',
+  })
+  const [status, setStatus] = useState('')
+
+  const handleChange = (e) => {
+    setFormData((prev) => ({ ...prev, [e.target.name]: e.target.value }))
+  }
+
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    setStatus('success')
+    setFormData({ name: '', email: '', subject: '', message: '' })
+    setTimeout(() => setStatus(''), 5000)
+  }
+
+  return (
+    <main className="min-h-screen bg-white dark:bg-gray-900">
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-orange-50 via-white to-amber-50 dark:from-gray-900 dark:via-gray-800 dark:to-orange-950 py-20 px-6 sm:py-28">
+        <div className="mx-auto max-w-4xl text-center">
+          <h1 className="text-4xl font-bold tracking-tight text-gray-900 dark:text-white sm:text-6xl bg-clip-text text-transparent bg-gradient-to-r from-gray-900 dark:from-gray-100 to-orange-600 dark:to-orange-400">
+            Get in Touch
+          </h1>
+          <p className="mt-6 text-lg leading-8 text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
+            Have a question, feedback, or just want to say hello? We'd love to hear from you.
+            Fill out the form below and we'll get back to you as soon as possible.
+          </p>
+        </div>
+      </section>
+
+      {/* Contact Info */}
+      <section className="py-12 px-6 border-y border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-800">
+        <div className="mx-auto max-w-7xl">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
+            <div className="text-center">
+              <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-orange-100 dark:bg-orange-900/50 text-orange-600 dark:text-orange-400 mb-4 text-xl">
+                @
+              </div>
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">Email</h3>
+              <p className="text-gray-600 dark:text-gray-400">hello@store.com</p>
+            </div>
+            <div className="text-center">
+              <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-orange-100 dark:bg-orange-900/50 text-orange-600 dark:text-orange-400 mb-4 text-xl">
+                #
+              </div>
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">Phone</h3>
+              <p className="text-gray-600 dark:text-gray-400">+1 (555) 123-4567</p>
+            </div>
+            <div className="text-center">
+              <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-orange-100 dark:bg-orange-900/50 text-orange-600 dark:text-orange-400 mb-4 text-xl">
+                ~
+              </div>
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">Address</h3>
+              <p className="text-gray-600 dark:text-gray-400">123 Store St, New York, NY</p>
+            </div>
+            <div className="text-center">
+              <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-orange-100 dark:bg-orange-900/50 text-orange-600 dark:text-orange-400 mb-4 text-xl">
+                *
+              </div>
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">Hours</h3>
+              <p className="text-gray-600 dark:text-gray-400">Mon–Fri, 9am–6pm EST</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Contact Form */}
+      <section className="py-20 px-6 sm:py-28">
+        <div className="mx-auto max-w-2xl">
+          <h2 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-white mb-8 text-center">
+            Send Us a Message
+          </h2>
+
+          {status === 'success' && (
+            <div className="mb-8 rounded-lg bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-800 p-4 text-center">
+              <p className="text-sm font-medium text-green-700 dark:text-green-300">
+                Thank you for your message! We'll get back to you shortly.
+              </p>
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+              <div>
+                <label htmlFor="name" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  Name
+                </label>
+                <input
+                  type="text"
+                  id="name"
+                  name="name"
+                  value={formData.name}
+                  onChange={handleChange}
+                  required
+                  className="w-full px-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-orange-600 dark:focus:ring-orange-400 transition-colors"
+                  placeholder="Your name"
+                />
+              </div>
+              <div>
+                <label htmlFor="email" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  Email
+                </label>
+                <input
+                  type="email"
+                  id="email"
+                  name="email"
+                  value={formData.email}
+                  onChange={handleChange}
+                  required
+                  className="w-full px-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-orange-600 dark:focus:ring-orange-400 transition-colors"
+                  placeholder="you@example.com"
+                />
+              </div>
+            </div>
+
+            <div>
+              <label htmlFor="subject" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                Subject
+              </label>
+              <input
+                type="text"
+                id="subject"
+                name="subject"
+                value={formData.subject}
+                onChange={handleChange}
+                required
+                className="w-full px-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-orange-600 dark:focus:ring-orange-400 transition-colors"
+                placeholder="What is this about?"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="message" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                Message
+              </label>
+              <textarea
+                id="message"
+                name="message"
+                value={formData.message}
+                onChange={handleChange}
+                required
+                rows={6}
+                className="w-full px-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-orange-600 dark:focus:ring-orange-400 transition-colors resize-none"
+                placeholder="Tell us how we can help..."
+              />
+            </div>
+
+            <button
+              type="submit"
+              className="w-full rounded-full bg-orange-600 dark:bg-orange-500 px-8 py-4 text-base font-semibold text-white shadow-lg hover:bg-orange-700 dark:hover:bg-orange-600 transition-all hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-orange-600 dark:focus:ring-orange-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+            >
+              Send Message
+            </button>
+          </form>
+        </div>
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

Added a contact page with a mockup form at `/contact`. The page includes a hero section, a contact information grid (email, phone, address, hours), and a form with name, email, subject, and message fields. The form uses client-side state with a mock submit handler that shows a success message. Updated existing placeholder Contact links in the Navigation and Footer components to point to `/contact`.

## Changes

- **`app/contact/page.js`** (new) — Contact page with three sections: gradient hero, contact info grid, and a styled form with mock submission feedback.
- **`app/components/Navigation.js`** — Updated Contact menu item href from `#` to `/contact`.
- **`app/components/Footer.js`** — Updated Contact support link href from `#` to `/contact`.

## How to Test

1. Run `npm run dev` and navigate to `/contact`
2. Verify the hero section, contact info cards, and form render correctly
3. Fill out and submit the form — a green success banner should appear for 5 seconds
4. Check dark mode toggle works on the contact page
5. Verify the Contact link in the navigation bar and footer both navigate to `/contact`

## Task Context

```
# Contact Page with Mockup Form

**Task ID:** eanan8

## Summary

Create contact page with mockup form

## Requirements

User requirements and acceptance criteria.

## Research Findings

**Relevant files:**
- `app/layout.js` - Root layout with header (Navigation, ThemeToggle), PeopleCarousel, and inline footer. Does NOT use the Footer component.
- `app/components/Navigation.js` - Nav menu with a "Contact" link currently pointing to `#` (placeholder). Needs updating to `/contact`.
- `app/components/Footer.js` - Footer component with a "Contact" link under Support also pointing to `#`. Needs updating to `/contact`.
- `app/about/page.js` - Example of a simple page pattern: `<main>` with `min-h-screen bg-white dark:bg-gray-900`, a section with `py-20 px-6 sm:py-32`, and `mx-auto max-w-4xl` wrapper.
- `app/globals.css` - Just Tailwind directives, no custom styles.
- `tailwind.config.js` - Dark mode via `class`, content scoped to `./app/**/*.{js,ts,jsx,tsx,mdx}`.

**Current behavior:**
- The site is a Next.js 14 store/e-commerce demo using Tailwind CSS with dark mode support.
- Navigation and Footer both have "Contact" links that point to `#` (non-functional).
- There is no existing contact page at `app/contact/page.js`.

**Dependencies:**
- Next.js 14, React 18, Tailwind CSS 3. No form libraries installed.
- The page should be a client component (`'use client'`) since it needs form state handling.

**Constraints:**
- This is a mockup form — no actual backend submission needed.
- Must follow existing design patterns: orange accent colors, dark mode support, consistent spacing and typography.
- Should match the Tailwind class conventions used across the project.

## Brainstorm

**Approach 1: Simple single-section contact form page**
Create `app/contact/page.js` as a client component with a single centered section containing a form (name, email, subject, message) and a mock submit handler that shows a success message. Minimal, matches the about page pattern.
- Complexity: Low — one new file, two link updates.
- Risk: Very low — no existing code modified beyond placeholder links.
- Maintainability: Clean and straightforward. Easy to extend later with real submission logic.

**Approach 2: Multi-section contact page with info sidebar + form**
Create a richer contact page with a two-column layout: left column with contact information (address, phone, email, hours) and right column with the form. Includes a hero/header area at the top.
- Complexity: Medium — more markup but still one file.
- Risk: Low — same as Approach 1 plus more content to maintain.
- Maintainability: Slightly more complex but provides a better user experience with contextual info alongside the form.

**Approach 3: Contact page with extracted form component**
Same as Approach 2 but extract the form into a reusable `app/components/ContactForm.js` component. Could be reused in a modal or other pages.
- Complexity: Medium — two new files instead of one.
- Risk: Low — but adds abstraction that may not be needed for a mockup.
- Maintainability: Better separation of concerns, but over-engineered for a mockup form with no real backend.

**Selected approach: Approach 2**
A multi-section page with contact info and form provides a realistic, professional contact page without over-engineering. It matches the visual richness of other pages in the project (hero sections, feature grids) while keeping everything in a single page file. Since this is a mockup, extracting a separate component (Approach 3) adds unnecessary complexity.

## File Tree

Files to modify or create:
- `app/contact/page.js` - New contact page with hero section, contact info grid, and mockup form
- `app/components/Navigation.js` - Update Contact link href from `#` to `/contact`
- `app/components/Footer.js` - Update Contact link href from `#` to `/contact`

## TODO List

- [x] Create `app/contact/page.js` with hero section, contact information grid (email, phone, address, hours), and a mockup form (name, email, subject, message) with client-side mock submit handler showing success feedback. Use existing design patterns: orange accents, dark mode, consistent spacing.
- [x] Update `app/components/Navigation.js` to change the Contact menu item href from `#` to `/contact`
- [x] Update `app/components/Footer.js` to change the Contact support link href from `#` to `/contact`
- [x] Verify the build passes with `npm run build`
```
